### PR TITLE
Script to reproduce basic stats reported in Anderson et al/ compare algorithm against them

### DIFF
--- a/eval/anderson.py
+++ b/eval/anderson.py
@@ -1,0 +1,96 @@
+import numpy as np
+from remodnav import EyegazeClassifier
+from remodnav.tests.test_labeled import load_data as load_anderson
+
+labeled_files = {
+    'dots': [
+        'TH20_trial1_labelled_{}.mat',
+        'TH38_trial1_labelled_{}.mat',
+        'TL22_trial17_labelled_{}.mat',
+        'TL24_trial17_labelled_{}.mat',
+        'UH21_trial17_labelled_{}.mat',
+        'UH21_trial1_labelled_{}.mat',
+        'UH25_trial1_labelled_{}.mat',
+        # following file is missing for RA
+        # https://github.com/richardandersson/EyeMovementDetectorEvaluation/issues/1
+        #'UH33_trial1_labelled_{}.mat',
+        'UL27_trial17_labelled_{}.mat',
+        'UL31_trial1_labelled_{}.mat',
+        'UL39_trial1_labelled_{}.mat',
+    ],
+    'images': [
+        'TH34_img_Europe_labelled_{}.mat',
+        'TH34_img_vy_labelled_{}.mat',
+        'TL20_img_konijntjes_labelled_{}.mat',
+        'TL28_img_konijntjes_labelled_{}.mat',
+        'UH21_img_Rome_labelled_{}.mat',
+        'UH27_img_vy_labelled_{}.mat',
+        'UH29_img_Europe_labelled_{}.mat',
+        'UH33_img_vy_labelled_{}.mat',
+        'UH47_img_Europe_labelled_{}.mat',
+        'UL23_img_Europe_labelled_{}.mat',
+        'UL31_img_konijntjes_labelled_{}.mat',
+        'UL39_img_konijntjes_labelled_{}.mat',
+        'UL43_img_Rome_labelled_{}.mat',
+        'UL47_img_konijntjes_labelled_{}.mat',
+    ],
+    'videos': [
+        'TH34_video_BergoDalbana_labelled_{}.mat',
+        'TH38_video_dolphin_fov_labelled_{}.mat',
+        'TL30_video_triple_jump_labelled_{}.mat',
+        'UH21_video_BergoDalbana_labelled_{}.mat',
+        'UH29_video_dolphin_fov_labelled_{}.mat',
+        'UH47_video_BergoDalbana_labelled_{}.mat',
+        'UL23_video_triple_jump_labelled_{}.mat',
+        'UL27_video_triple_jump_labelled_{}.mat',
+        'UL31_video_triple_jump_labelled_{}.mat',
+    ],
+}
+
+
+def get_durations(events, evcodes):
+    events = [e for e in events if e['label'] in evcodes]
+    # TODO minus one sample at the end?
+    durations = [e['end_time'] - e['start_time'] for e in events]
+    return durations
+
+
+for stimtype in ('images', 'dots', 'videos'):
+#for stimtype in ('images', 'videos'):
+    for coder in ('MN', 'RA'):
+        print(stimtype, coder)
+        fixation_durations = []
+        saccade_durations = []
+        pso_durations = []
+        purs_durations = []
+        for fname in labeled_files[stimtype]:
+            data, target_labels, target_events, px2deg, sr = load_anderson(
+                stimtype, fname.format(coder))
+            fixation_durations.extend(get_durations(
+                target_events, ['FIXA']))
+            saccade_durations.extend(get_durations(
+                target_events, ['SACC']))
+            pso_durations.extend(get_durations(
+                target_events, ['PSO']))
+            purs_durations.extend(get_durations(
+                target_events, ['PURS']))
+        print(
+            'FIX: %.3f (%.3f) [%i]' % (
+                np.mean(fixation_durations),
+                np.std(fixation_durations),
+                len(fixation_durations)))
+        print(
+            'SAC: %.3f (%.3f) [%i]' % (
+                np.mean(saccade_durations),
+                np.std(saccade_durations),
+                len(saccade_durations)))
+        print(
+            'PSO: %.3f (%.3f) [%i]' % (
+                np.mean(pso_durations),
+                np.std(pso_durations),
+                len(pso_durations)))
+        print(
+            'PURS: %.3f (%.3f) [%i]' % (
+                np.mean(purs_durations),
+                np.std(purs_durations),
+                len(purs_durations)))

--- a/eval/anderson.py
+++ b/eval/anderson.py
@@ -194,6 +194,30 @@ def confusion(refcoder, coder):
             (np.sum(conf) / nsamples) * 100,
             (np.sum(conf[:3, :3]) / nsamples_nopurs) * 100))
         plotter += 1
+        msclf_refcoder = dict(zip(conditions, conf.sum(axis=1)/conf.sum() * 100))
+        msclf_coder = dict(zip(conditions, conf.sum(axis=0)/conf.sum() * 100))
+        print('### {}'.format(stimtype))
+        print('Comparison | MCLF | MCLFw/oP | Method | Fix | Sacc | PSO | SP')
+        print('--- | --- | --- | --- | --- | --- | --- | ---')
+        print('{} v {} | {:.1f} | {:.1f} | {} | {:.0f} | {:.0f} | {:.0f} | {:.0f}'.format(
+            refcoder,
+            coder,
+            (np.sum(conf) / nsamples) * 100,
+            (np.sum(conf[:3, :3]) / nsamples_nopurs) * 100,
+            refcoder,
+            msclf_refcoder['FIX'],
+            msclf_refcoder['SAC'],
+            msclf_refcoder['PSO'],
+            msclf_refcoder['PUR'],
+        ))
+        print('-- | --  | -- | {} | {:.0f} | {:.0f} | {:.0f} | {:.0f}'.format(
+            coder,
+            msclf_coder['FIX'],
+            msclf_coder['SAC'],
+            msclf_coder['PSO'],
+            msclf_coder['PUR'],
+        ))
+
 
 
 confusion('MN', 'RA')


### PR DESCRIPTION
ATM we cannot reproduce (reason is subject to research). Here is a summary of the differences: duration stats for fixations, saccades, PSOs and pursuits. The first value is our's, the one in parenthesis is the one reported in the paper. Note, our values are not own detection results, but stats computed from their released data. Subjectively substantial deviations are in **BOLD**, although there really should be no deviations at all, and the code to compute all stats is the same for all events (see PR).

Conclusion: We get what is in the paper for saccades and PSOs, but something substantially different for number of fixations.

### Fixation durations
Coder | IMG-Mean | IMG-SD | IMG-No | VID-Mean | VID-SD | VID-No
--- | --- | --- | --- | --- | --- | ---
MN | 252 (248) | 285 (271) | **403 (380)** | 304 (318) | 277 (289) | **82 (67)**
RA | 247 (242) | 288 (273) | **391 (369)** | 232 (240) | 177 (189) | **81 (67)**

### Saccade durations
Coder | IMG-Mean | IMG-SD | IMG-No | VID-Mean | VID-SD | VID-No
--- | --- | --- | --- | --- | --- | ---
MN | 29 (30) | 17 (17) | 377 (376) | 26 (26) | 13 (13) | 117 (116)
RA | 31 (31) | 15 (15) | 374 (372) | 25 (25) | 12 (12) | 127 (126)

### PSO durations
Coder | IMG-Mean | IMG-SD | IMG-No | VID-Mean | VID-SD | VID-No
--- | --- | --- | --- | --- | --- | ---
MN | 21 (21) | 11 (11) | 313 (312) | 20 (20) | 11 (11) | 97 (97)
RA | 21 (21) | 9 (9) | 310 (309) | 17 (17) | 8 (8) | 89 (89)

### Pursuit durations
Coder | IMG-Mean | IMG-SD | IMG-No | VID-Mean | VID-SD | VID-No
--- | --- | --- | --- | --- | --- | ---
MN | 363 (363) | **153 (187)** | 3 (3) | 528 (521) | 344 (347) | 51 (50)
RA | 299 (305) | 175 (184) | 17 (16) | 481 (472) | 317 (319) | 70 (68)

## Confusions

Assuming we make no mistakes extracting the Anderson labels, here is how our algorithm performs re confusions. 

### MN vs. RA

This gives us the baseline

![image](https://user-images.githubusercontent.com/136479/45535233-1499cc80-b7fe-11e8-929d-5231bea2de74.png)

### algorithm vs. coder MN
![image](https://user-images.githubusercontent.com/136479/45535318-5d518580-b7fe-11e8-9d8f-87aaac0d9bd9.png)

### algorithm vs. coder RA
![image](https://user-images.githubusercontent.com/136479/45535340-6fcbbf00-b7fe-11e8-827c-6072ffe75370.png)

## Mis-classification summary stats

For all pairwise comparisons, this shows the overall misclassification rate (using timepoints as unit of measure, and limited to timepoints that have been labeled with FIX, SAC, PSO, or PUR by any method, hence ignoring NaN/blinks and undefined (which is rarely used)), same misclassification rate as before, but ignoring PUR events too. The remaining numbers are percentages of labels used in die misclassified samples. In contrast to the paper the method label that is misclassifying is given (not "over" and "under", as I found this confusing).

### images

Analog to table 8 in the paper

Comparison | MCLF | MCLFw/oP | Method | Fix | Sacc | PSO | SP
--- | --- | --- | --- | --- | --- | --- | ---
MN v RA | 6.2 | 3.1 | MN | 68 | 11 | 21 | 0
-- | --  | -- | RA | 15 | 14 | 20 | 52
MN v ALGO | 33.3 | 11.2 | MN | 88 | 1 | 10 | 1
-- | --  | -- | ALGO | 2 | 16 | 8 | 74
RA v ALGO | 33.6 | 10.4 | RA | 81 | 2 | 9 | 8
-- | --  | -- | ALGO | 7 | 16 | 8 | 69


### dots

Analog to table 9 in the paper

Comparison | MCLF | MCLFw/oP | Method | Fix | Sacc | PSO | SP
--- | --- | --- | --- | --- | --- | --- | ---
MN v RA | 11.1 | 5.0 | MN | 11 | 9 | 9 | 71
-- | --  | -- | RA | 64 | 7 | 6 | 23
MN v ALGO | 23.9 | 9.7 | MN | 10 | 1 | 6 | 83
-- | --  | -- | ALGO | 74 | 8 | 5 | 12
RA v ALGO | 26.7 | 10.4 | RA | 25 | 2 | 4 | 69
-- | --  | -- | ALGO | 60 | 10 | 5 | 25

### videos

Analog to table 10 in the paper

Comparison | MCLF | MCLFw/oP | Method | Fix | Sacc | PSO | SP
--- | --- | --- | --- | --- | --- | --- | ---
MN v RA | 18.5 | 4.0 | MN | 75 | 3 | 8 | 15
-- | --  | -- | RA | 16 | 4 | 3 | 77
MN v ALGO | 38.1 | 10.6 | MN | 37 | 1 | 5 | 58
-- | --  | -- | ALGO | 54 | 9 | 6 | 31
RA v ALGO | 38.6 | 11.7 | RA | 22 | 1 | 4 | 73
-- | --  | -- | ALGO | 66 | 10 | 7 | 17

## Interim conclusion

Performance looks good. Without pursuit this looks better than the stats in the paper (although I am not 100% confident that we compute things the exact same way). Confusion patterns with and without pursuit look sensible.

Critical feedback appreciated!