### PR TITLE
Minor labeling issue in one datafile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/psychoinformatics-de/studyforrest-data-phase2.git
 [submodule "remodnav/tests/data/anderson_etal"]
 	path = remodnav/tests/data/anderson_etal
-	url = https://github.com/richardandersson/EyeMovementDetectorEvaluation.git
+	url = https://github.com/AdinaWagner/AndersonsData.git


### PR DESCRIPTION
Up  front: I'm not entirely sure I did the correct thing in the anderson_etal subdataset -- please check.

There is a very recent [paper](http://sci-hub.tw/https://link.springer.com/article/10.3758/s13428-018-1133-5) which I assume we should cite. They report a minor labeling mistake in Appendix 2 for 75 samples.
Since its out there reported, we should probably adjust the file. I [checked back](https://github.com/richardandersson/EyeMovementDetectorEvaluation/issues/2) with Richard Anderson, and the file is not fixed in his repo. Its impact on the results is tiny, though. If I rerun the analyses with the fix, we see an improvement in the magnitude of one decimal in misclassification rate and the Jaccard index in the respective places.
I datalad added a fixed file (`UH29_img_Europe_labelled_FIX_MN.mat`) to the subdataset, and renamed the corresponding RA equivalent, and adjusted the `anderson.py` and `test_labeled.py` scripts to use the new file. However, given that I only see an updated submodule hash in the summary of this PR, I'm not entirely sure that this did what I wanted it to do -- so if not, I'd appreciate guidance in how to update the submodule correctly.