### PR TITLE
Specified expected CSV-format in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ command line call:
 - ``infile``: Data file with eye gaze recordings to process. The first two columns
   in this file must contain x and y coordinates, while each line is a timepoint
   (no header). The file is read with NumPy's ``recfromcsv`` and may be compressed.
+  The columns are expected to be seperated by tabulators (``\t``).
 - ``outfile``: Output file name. This file will contain information on all detected
   eye movement events in BIDS events.tsv format.
 - ``px2deg``: Factor to convert pixel coordinates to visual degrees, i.e. the visual


### PR DESCRIPTION
Dear Maintainers,

I tried to read some data with remodnav but only got errors in the process. After checking the code, I realized, that my assumption, that the CSV would use commas as delimiters was wrong (tabstops are expected). I would recommend to reflect this in the README.md. 🙂 

Kind Regards,
Jonathan