### PR TITLE
BF: Loosen savgol-filter warning to allow disabling the filter

### DIFF
--- a/remodnav/clf.py
+++ b/remodnav/clf.py
@@ -808,8 +808,9 @@ class EyegazeClassifier(object):
         min_blink_duration = int(min_blink_duration * self.sr)
         # sanity check window length - it needs to be odd, and greater than the
         # polynomial order of the Savitzgy-Golay filter
-        if int(savgol_length * self.sr) % 2 != 1 or \
-            int(savgol_length * self.sr) < savgol_polyord:
+        if (int(savgol_length * self.sr) % 2 != 1 or
+            int(savgol_length * self.sr) < savgol_polyord) and \
+                savgol_length != 0.0:
             raise ValueError("\n"\
                 "Inappropriate window size for Savitzgy-Golay "\
                 "filter. Please adjust --savgol-length such that the "\


### PR DESCRIPTION
A previous PR (#20) introduced a basic check for the parametrization of the Savitzgy Golay filter.
It missed a condition for a window_length of 0 (i.e., disabling the filter), and would also crash
in those cases. This change rectifies this, and let's a window length of zero pass.