### PR TITLE
Safeguard against edgecases with only nan velocities

### DIFF
--- a/remodnav/clf.py
+++ b/remodnav/clf.py
@@ -273,6 +273,8 @@ class EyegazeClassifier(object):
 
     def _get_signal_props(self, data):
         data = data[~np.isnan(data['vel'])]
+        if not len(data):
+            return np.nan, np.nan, np.nan, np.nan
         pv = data['vel'].max()
         amp = (((data[0]['x'] - data[-1]['x']) ** 2 + \
                 (data[0]['y'] - data[-1]['y']) ** 2) ** 0.5) * self.px2deg
@@ -894,13 +896,16 @@ class EyegazeClassifier(object):
                 vel = filtered_velocities[-1]
             filtered_velocities.append(vel)
         velocities = np.array(filtered_velocities)
-
+        if not median_filter_length:
+            # no median filtering, but we need the field in our dict later,
+            # so we just reuse the original velocities
+            med_velocities = velocities
         # acceleration is change of velocities over the last time unit
         acceleration = np.zeros(velocities.shape, velocities.dtype)
         acceleration[1:] = (velocities[1:] - velocities[:-1]) * self.sr
 
-        arrs = [med_velocities] if median_filter_length else []
-        names = ['med_vel'] if median_filter_length else []
+        arrs = [med_velocities]
+        names = ['med_vel']
         arrs.extend([
             velocities,
             acceleration,

--- a/remodnav/tests/test_preproc.py
+++ b/remodnav/tests/test_preproc.py
@@ -85,7 +85,6 @@ def test_preproc():
     # 2 deg in 0.1s -> 20deg/s
     assert p['vel'][-1] == 20
     assert p['accel'][-1] == 200
-    assert 'med_vel' not in p.dtype.names
 
     data['x'][1] = 200
     p = clf.preproc(data.copy(), savgol_length=0, dilate_nan=0)


### PR DESCRIPTION
We never hit this due to higher sampling rates, but #35 reports an unfortunate clash of data properties that cause a crash due to data segments with only ``nan`` velocities being processed. This is not a pretty but at least a basic safeguard. Any output that suffers from such a condition does not have a number of properties, such as peak velocity, average velocity or amplitude as a result, simply because they can't be computed.