### PR TITLE
Replace deprecated getargspec from inspect module with getfullargspec

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,7 +64,7 @@ environment:
     #  PY: 39-x64
     # MacOS core tests
     - ID: MacP38core
-      APPVEYOR_BUILD_WORKER_IMAGE: macOS
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
       PY: 3.8
       # does not give a functional installation
       # INSTALL_GITANNEX: git-annex -m snapshot

--- a/remodnav/__init__.py
+++ b/remodnav/__init__.py
@@ -74,7 +74,7 @@ def main(args=sys.argv):
     kwargs = {}
     for func in (EyegazeClassifier.__init__, EyegazeClassifier.preproc):
         # pull kwargs and their defaults out of the function definitions
-        argspec = inspect.getargspec(func)
+        argspec = inspect.getfullargspec(func)
         kwargs.update(zip(argspec.args[::-1], argspec.defaults[::-1]))
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
``inspect.getargspec`` has been deprecated already in Python 3.0, but was still around until being [removed in version 3.11](https://docs.python.org/3.11/whatsnew/3.11.html#removed). This change replaces ``getargspec`` with the drop-in-replacement ``getfullargspec``