### PR TITLE
Revert "Disable Windows CI for now (gh-23)"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,10 +58,10 @@ environment:
       # system git-annex is way too old, use better one
       INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
     # Windows core tests
-    #- ID: WinP39core
-    #  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    #  # Python version specification is non-standard on windows
-    #  PY: 39-x64
+    - ID: WinP39core
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      # Python version specification is non-standard on windows
+      PY: 39-x64
     # MacOS core tests
     - ID: MacP38core
       APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey


### PR DESCRIPTION
This reverts commit 7577dc042fe57ba55d7fdc74d1ed9edda8da498f.
I have a suspicion that the Windows issue got fixed when we reconfigured the special remotes of the studyforrest datasets a few months ago.